### PR TITLE
Fakesmtp web upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,27 @@ Run the jar maven created in the target folder of the project root directory.
 
 `java -jar target/fakesmtp-web-1.0.jar`
 
+# Set context path
+Step 1.
+When you want to set context path, you can do it for spring boot using `server.servlet.context-path` property.
+In addition you need to update the `FAKE_SMTP_WEB_API` variable.
+for example if you add context path as 
+`server.servlet.context-path=/mail`
+append the context to `FAKE_SMTP_WEB_API` as below
+`http://localhost:8080 -> http://localhost:8080/mail` 
+
+Same applies to port number as well.
+Note : for standalone(no docker) implementation we can keep same port number. 
+
+Step 2.
+Change `publicPath` in file below to update the context path. 
+src\main\ui\webpack.config.js
+for eg. if context path is `/mail` make change as 
+`const publicPath = (env === 'prod') ? '/ui/' : '/';`
+`const publicPath = (env === 'prod') ? '/mail/ui/' : '/';`
+
+Step 3.
+Recompile the application using step 3 mentioned above.
 
 # Implementation details
 - Spring Boot

--- a/src/main/ui/package.json
+++ b/src/main/ui/package.json
@@ -31,5 +31,8 @@
     "webpack": "^3.10.0",
     "webpack-cli": "^3.2.1",
     "webpack-dev-server": ">=3.1.11"
+  },
+  "resolutions": {
+    "graceful-fs": "^4.2.4"
   }
 }


### PR DESCRIPTION
Fixing the issues I faced while setting up without using docker.
Adding 2 changes below,
1. Support to Node.js 12+
Updating a legacy project depending on gulp@3.9.1 to Node.js 12+.
These fixes enable you to use Node.js 12+ with gulp@3.9.1 by overriding graceful-fs to version ^4.2.4.

2. Added tips to use without docker.
These tips will help users to troubleshoot setting spring properties like context path, port number etc.